### PR TITLE
Lower log level

### DIFF
--- a/src/memote_webservice/resources/submit.py
+++ b/src/memote_webservice/resources/submit.py
@@ -89,7 +89,7 @@ class Submit(MethodResource):
                     f"'{file_storage.mimetype}' is an unhandled MIME type. "
                     f"Recognized MIME types are: {mime_types}"
                 )
-                LOGGER.error(msg)
+                LOGGER.warning(msg)
                 abort(415, msg)
         except (CobraSBMLError, ValueError) as err:
             msg = "Failed to parse model."


### PR DESCRIPTION
Lowers the log level for the case when a client uploads a file with an invalid mimetype. I don't think this situation warrants a notification and investigation.

See also: https://sentry.io/technical-university-of-denmark/memote-webservice/issues/770429700/