### PR TITLE
Disable sympy cache in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.6-slim
 
 ENV PYTHONUNBUFFERED=1
+# The sympy cache causes significant memory leaks as it is currently used by
+# optlang. Disable it by default.
+ENV SYMPY_USE_CACHE=no
 
 ENV APP_USER=kaa
 ENV HOME="/home/${APP_USER}"

--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -59,9 +59,6 @@ spec:
         env:
         - name: REDIS_URL
           value: redis://localhost:6379/0
-        # Disabling sympy cache prevents significant memory leaks in the cobrapy stack
-        - name: SYMPY_USE_CACHE
-          value: "no"
         command: ["celery", "-A", "memote_webservice.tasks", "worker", "--loglevel=info"]
         resources:
           requests:


### PR DESCRIPTION
We need explicit disabling of the cache here as this service is not using the modeling base image. I suppose that's because it's not part of the decaf platform.