### PR TITLE
 Fix: prevent parallel processing in memote tests

### DIFF
--- a/src/memote_webservice/resources/submit.py
+++ b/src/memote_webservice/resources/submit.py
@@ -123,7 +123,7 @@ class Submit(MethodResource):
 
     @staticmethod
     def _dump_model(filename, content):
-        unqiue_filename = f"{str(uuid4())}_{werkzeug.secure_filename(filename)}"
-        LOGGER.warning(f"Dumping uploaded model to '{unqiue_filename}'")
-        with open(unqiue_filename, 'wb') as file_:
+        unique_filename = f"{str(uuid4())}_{werkzeug.secure_filename(filename)}"
+        LOGGER.warning(f"Dumping uploaded model to '{unique_filename}'")
+        with open(unique_filename, 'wb') as file_:
             file_.write(content.getvalue())

--- a/src/memote_webservice/tasks.py
+++ b/src/memote_webservice/tasks.py
@@ -15,6 +15,7 @@
 
 """Define individual jobs."""
 
+import cobra
 import memote
 
 from .celery import celery_app
@@ -23,6 +24,8 @@ from .celery import celery_app
 @celery_app.task
 def model_snapshot(model):
     """Run memote on the given model and create a snapshot report."""
+    configuration = cobra.Configuration()
+    configuration.processes = 1
     _, result = memote.test_model(model, results=True,
                                   pytest_args=["-vv", "--tb", "long"])
     config = memote.ReportConfiguration.load()


### PR DESCRIPTION
Celery cannot spawn additional processes from the daemon worker.