### PR TITLE
Use SBML validation logic from memote

### DIFF
--- a/src/memote_webservice/errorhandlers.py
+++ b/src/memote_webservice/errorhandlers.py
@@ -27,6 +27,8 @@ from flask import jsonify
 from werkzeug.exceptions import HTTPException
 from werkzeug.routing import RoutingException
 
+from memote_webservice.exceptions import SBMLValidationError
+
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +36,7 @@ logger = logging.getLogger(__name__)
 def init_app(app):
     app.register_error_handler(422, handle_webargs_error)
     app.register_error_handler(HTTPException, handle_http_error)
+    app.register_error_handler(SBMLValidationError, handle_sbml_error)
     app.register_error_handler(Exception, handle_uncaught_error)
 
 
@@ -67,6 +70,17 @@ def handle_http_error(error):
         response = jsonify({'message': error.description})
         response.status_code = error.code
         return response
+
+
+def handle_sbml_error(error):
+    """Handle SBMLValidationError."""
+    response = jsonify({
+        'code': 'sbml_validation_failure',
+        'warnings': error.warnings,
+        'errors': error.errors,
+    })
+    response.status_code = error.code
+    return response
 
 
 def handle_uncaught_error(error):

--- a/src/memote_webservice/exceptions.py
+++ b/src/memote_webservice/exceptions.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2018, Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class SBMLValidationError(Exception):
+    def __init__(self, code, warnings, errors, *args, **kwargs):
+        super().__init__(self, *args, **kwargs)
+        self.code = code
+        self.warnings = warnings
+        self.errors = errors


### PR DESCRIPTION
This uses memote's `memote.api.validate_model` to load SBML models, and adds a new error handler which forwards the warnings and errors to the web client.

See also https://github.com/DD-DeCaF/memote-service-frontend/pull/19