### PR TITLE
Add libssl-dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux \
     && apt-get update \
     && apt-get install --yes --only-upgrade openssl ca-certificates \
     && apt-get install --yes --no-install-recommends \
-        g++ \
+        g++ libssl-dev \
     && pip install --upgrade pip==9.0.3 setuptools wheel \
     && pip install -r requirements.in -r dev-requirements.in \
     && rm -rf /root/.cache/pip \


### PR DESCRIPTION
Fixes the recent build issues:

    build/temp.linux-x86_64-3.6/_openssl.c:498:30: fatal error: openssl/opensslv.h: No such file or directory
     #include <openssl/opensslv.h>
                                  ^
    compilation terminated.
    error: command 'gcc' failed with exit status 1