### PR TITLE
Always store uploaded models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Ignore uploaded model files (excluding the README)
+/models/*
+!/models/README
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/models/README
+++ b/models/README
@@ -1,0 +1,1 @@
+Uploaded models will be stored in this directory for temporary posterity.

--- a/src/memote_webservice/resources/report.py
+++ b/src/memote_webservice/resources/report.py
@@ -48,7 +48,15 @@ class Report(MethodResource):
                 'message': str(exception),
             })
         else:
-            report = result.get()
+            try:
+                _, report = result.get()
+            except TypeError:
+                # Expected for results generated before the result type changed.
+                # When those results expire (about 2 weeks from 2019-03-27
+                # assuming this commit is deployed today), this handler can be
+                # removed.
+                report = result.get()
+
             mime_type = request.accept_mimetypes.best_match([
                 'text/html',
                 'application/json',

--- a/src/memote_webservice/tasks.py
+++ b/src/memote_webservice/tasks.py
@@ -29,4 +29,5 @@ def model_snapshot(model):
     _, result = memote.test_model(model, results=True,
                                   pytest_args=["-vv", "--tb", "long"])
     config = memote.ReportConfiguration.load()
-    return memote.SnapshotReport(result=result, configuration=config)
+    report = memote.SnapshotReport(result=result, configuration=config)
+    return model, report


### PR DESCRIPTION
* Always store uploaded models to disk and log their filename (not just on load failure)
* Place the models in `/models/` subdir
* Store models along with the report in the task results

This should help with being able to always find the original model when issues occur on various unexpected places in the pipeline, and hence debug those issues.