### PR TITLE
Remove structlog for now

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,8 +4,6 @@ flask-apispec
 gunicorn
 gevent
 raven[flask]
-structlog
-python-json-logger
 webargs
 werkzeug
 celery[redis]

--- a/src/memote_webservice/app.py
+++ b/src/memote_webservice/app.py
@@ -19,17 +19,15 @@ import logging
 import logging.config
 import os
 
-import structlog
 from flask import Flask
 from flask_cors import CORS
-from pythonjsonlogger import jsonlogger
 from raven.contrib.flask import Sentry
 from werkzeug.contrib.fixers import ProxyFix
 
 from . import errorhandlers
 
 
-LOGGER = structlog.get_logger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 app = Flask(__name__)
 
@@ -48,27 +46,6 @@ def init_app(application):
 
     # Configure logging
     logging.config.dictConfig(application.config["LOGGING"])
-    root_logger = logging.getLogger()
-    for handler in root_logger.handlers:
-        handler.setFormatter(jsonlogger.JsonFormatter())
-    structlog.configure(
-        processors=[
-            structlog.stdlib.filter_by_level,
-            structlog.stdlib.add_logger_name,
-            structlog.stdlib.add_log_level,
-            structlog.processors.TimeStamper(fmt="iso"),
-            structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
-            structlog.processors.UnicodeDecoder(),
-            structlog.stdlib.render_to_log_kwargs,
-        ],
-        # comment
-        context_class=dict,
-        logger_factory=structlog.stdlib.LoggerFactory(),
-        wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=True,
-    )
 
     # Configure Sentry
     if application.config["SENTRY_DSN"]:

--- a/src/memote_webservice/resources/report.py
+++ b/src/memote_webservice/resources/report.py
@@ -15,7 +15,8 @@
 
 """Provide a resource for retrieving test results."""
 
-import structlog
+import logging
+
 from celery.result import AsyncResult
 from flask import jsonify, make_response, render_template, request
 from flask_apispec import MethodResource, doc, marshal_with
@@ -25,7 +26,7 @@ from memote_webservice.celery import celery_app
 
 __all__ = ("Report",)
 
-LOGGER = structlog.get_logger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 class Report(MethodResource):

--- a/src/memote_webservice/resources/status.py
+++ b/src/memote_webservice/resources/status.py
@@ -15,7 +15,8 @@
 
 """Provide a resource for retrieving test results."""
 
-import structlog
+import logging
+
 from celery.result import AsyncResult
 from flask_apispec import MethodResource, doc, marshal_with
 
@@ -25,7 +26,7 @@ from memote_webservice.schemas import StatusResponse
 
 __all__ = ("Status",)
 
-LOGGER = structlog.get_logger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 class Status(MethodResource):

--- a/src/memote_webservice/resources/submit.py
+++ b/src/memote_webservice/resources/submit.py
@@ -15,6 +15,7 @@
 
 """Provide a resource to submit models for testing."""
 
+import logging
 import tempfile
 from bz2 import BZ2File
 from gzip import GzipFile
@@ -23,7 +24,6 @@ from itertools import chain
 from uuid import uuid4
 
 import memote
-import structlog
 import werkzeug
 from cobra.io import load_json_model
 from cobra.io.sbml import CobraSBMLError
@@ -37,7 +37,7 @@ from memote_webservice.tasks import model_snapshot
 
 __all__ = ("Submit",)
 
-LOGGER = structlog.get_logger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 class Submit(MethodResource):

--- a/src/memote_webservice/settings.py
+++ b/src/memote_webservice/settings.py
@@ -59,7 +59,10 @@ class Default:
             'disable_existing_loggers': False,
             'formatters': {
                 'simple': {
-                    'format': "%(message)s",
+                    'format': (
+                        "%(asctime)s [%(levelname)s] [%(name)s] %(filename)s:%("
+                        "funcName)s:%(lineno)d | %(message)s"
+                    )
                 },
             },
             'handlers': {


### PR DESCRIPTION
Since we're still not using any log management tool, it's an annoyance to have to parse the JSON log output manually. Until we pick this back up I'd like to put structlog on hold in favor of a bit more human readable text output.