### PR TITLE
Increase redis memory limit

### DIFF
--- a/deployment/deployment.yml
+++ b/deployment/deployment.yml
@@ -98,7 +98,7 @@ spec:
             cpu: "10m"
           limits:
             cpu: "2000m"
-            memory: "512Mi"
+            memory: "8Gi"
         volumeMounts:
           - mountPath: "/data"
             name: memote-webservice-production

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,3 +1,4 @@
+pytest
 pytest-cov
 pytest-mock
 flake8

--- a/requirements.in
+++ b/requirements.in
@@ -13,4 +13,3 @@ flower
 # version, so pin it explicitly here.
 tornado<6
 memote>=0.9.11
-pytest<4.1


### PR DESCRIPTION
As the current in-memory size is close to the limit, writing RDB
snapshots starts to fail with the following message:

    384:C 30 Sep 18:44:11.315 # Write error saving DB on disk: Out of memory

To accommodate for this, we raise the upper limit for now. We have a lot
of available memory in the cluster, so spiking a bit sometimes in order
to save the snapshots should not be problematic.

Not sure why redis is using this much memory; likely candidates are
large and/or many memote reports, or the fact that Celery requires that
much data. This should potentially be investigated in the future.